### PR TITLE
25.17.4

### DIFF
--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -28,7 +28,19 @@ using Service::DSP::DSP_DSP;
 
 namespace AudioCore {
 
-static constexpr u64 audio_frame_ticks_full_speed = 1310252ull; ///< Units: ARM11 cycles
+// TODO(xperia64): The value below is the "perfect" mathematical ratio
+// of ARM11 cycles per audio frame. As per merry, this was calculated to be
+// (ARM11 freq)*(samples per frame)/(sample rate)
+// = (268,111,855.956 Hz) * (160 samples)/(32,728 Hz)
+// = (1310739.946008311...) ~ 1310740
+//
+// This value was originally set to 1310252, which was determined by measuring it on hardware
+// However, as of when this was written, Project Mirai 1/2/DX desync on HLE
+// such that the music track runs ahead of the gameplay.
+// When the value is set to 1310740, all three games are playable
+// The audio track only drifts ~1ms over a 4+ minute song compared to hardware
+// and the button presses match as well as I can determine by playing the game/recording
+static constexpr u64 audio_frame_ticks_full_speed = 1310740ull; ///< Units: ARM11 cycles
 
 struct DspHle::Impl final {
 public:

--- a/src/common/version.cpp
+++ b/src/common/version.cpp
@@ -5,6 +5,6 @@
 #include "common/version.h"
 
 namespace version {
-const semver::version vvctre{25, 17, 3};
+const semver::version vvctre{25, 17, 4};
 const u8 movie = 2;
 } // namespace version

--- a/src/vvctre/emu_window/emu_window_sdl2.cpp
+++ b/src/vvctre/emu_window/emu_window_sdl2.cpp
@@ -2084,13 +2084,11 @@ void EmuWindow_SDL2::SwapBuffers() {
                         ipc_records.clear();
 
                         if (!show_ipc_recorder_window) {
-                            ipc_recorder_enabled = false;
+                            IPCDebugger::Recorder& r = system.Kernel().GetIPCRecorder();
 
-                            IPCDebugger::Recorder& r =
-                                Core::System::GetInstance().Kernel().GetIPCRecorder();
-
-                            r.SetEnabled(ipc_recorder_enabled);
+                            r.SetEnabled(false);
                             r.UnbindCallback(ipc_recorder_callback);
+
                             ipc_recorder_callback = nullptr;
                         }
                     }
@@ -2393,12 +2391,13 @@ void EmuWindow_SDL2::SwapBuffers() {
         ImGui::SetNextWindowSize(ImVec2(480, 640), ImGuiCond_Appearing);
         if (ImGui::Begin("IPC Recorder", &show_ipc_recorder_window,
                          ImGuiWindowFlags_NoSavedSettings)) {
-            if (ImGui::Checkbox("Enabled", &ipc_recorder_enabled)) {
-                IPCDebugger::Recorder& r = Core::System::GetInstance().Kernel().GetIPCRecorder();
+            IPCDebugger::Recorder& r = system.Kernel().GetIPCRecorder();
+            bool enabled = r.IsEnabled();
 
-                r.SetEnabled(ipc_recorder_enabled);
+            if (ImGui::Checkbox("Enabled", &enabled)) {
+                r.SetEnabled(enabled);
 
-                if (ipc_recorder_enabled) {
+                if (enabled) {
                     ipc_recorder_callback =
                         r.BindCallback([&](const IPCDebugger::RequestRecord& record) {
                             ipc_records[record.id] = record;
@@ -2518,12 +2517,12 @@ void EmuWindow_SDL2::SwapBuffers() {
         }
         if (!show_ipc_recorder_window) {
             ipc_records.clear();
-            ipc_recorder_enabled = false;
 
-            IPCDebugger::Recorder& r = Core::System::GetInstance().Kernel().GetIPCRecorder();
+            IPCDebugger::Recorder& r = system.Kernel().GetIPCRecorder();
 
-            r.SetEnabled(ipc_recorder_enabled);
+            r.SetEnabled(false);
             r.UnbindCallback(ipc_recorder_callback);
+
             ipc_recorder_callback = nullptr;
         }
         ImGui::End();

--- a/src/vvctre/emu_window/emu_window_sdl2.h
+++ b/src/vvctre/emu_window/emu_window_sdl2.h
@@ -95,7 +95,6 @@ private:
     Core::System& system;
     ImVec4 fps_color{0.0f, 1.0f, 0.0f, 1.0f}; // Green
 
-    bool ipc_recorder_enabled = false;
     IPCDebugger::CallbackHandle ipc_recorder_callback;
     std::map<int, IPCDebugger::RequestRecord> ipc_records;
 


### PR DESCRIPTION
### Changes

- Port https://github.com/citra-emu/citra/pull/5266
- Fix: IPC recorder says it's enabled and no new records are added after restarting emulation