### PR TITLE
29.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,8 @@ message(STATUS "Target architecture: ${ARCHITECTURE}")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# set up output paths for executable binaries
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
-
+# Set up output paths for executable binaries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/$<CONFIG>)
 
 # System imported libraries
 # ======================

--- a/dist/vvctre.manifest
+++ b/dist/vvctre.manifest
@@ -1,24 +1,58 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
- <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-  <security>
-   <requestedPrivileges>
-    <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
-   </requestedPrivileges>
-  </security>
- </trustInfo>
- <application xmlns="urn:schemas-microsoft-com:asm.v3">
-  <windowsSettings>
-   <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
-   <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
-  </windowsSettings>
- </application>
- <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-  <application>
-   <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-   <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-   <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-   <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-  </application>
- </compatibility>
+<assembly manifestVersion="1.0"
+    xmlns="urn:schemas-microsoft-com:asm.v1"
+    xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <!-- Windows 7/8/8.1/10 -->
+      <dpiAware
+        xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+        true/pm
+      </dpiAware>
+      <!-- Windows 10, version 1607 or later -->
+      <dpiAwareness
+        xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        PerMonitorV2
+      </dpiAwareness>
+      <!-- Windows 10, version 1703 or later -->
+      <gdiScaling
+          xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">
+        true
+      </gdiScaling>
+      <ws2:longPathAware
+          xmlns:ws3="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        true
+      </ws2:longPathAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+  <compatibility
+      xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    </application>
+  </compatibility>
+  <trustInfo
+      xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!--
+          UAC settings:
+          - app should run at same integrity level as calling process
+          - app does not need to manipulate windows belonging to
+            higher-integrity-level processes
+          -->
+        <requestedExecutionLevel
+            level="asInvoker"
+            uiAccess="false"
+        />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
 </assembly>

--- a/src/core/cheats/cheats.cpp
+++ b/src/core/cheats/cheats.cpp
@@ -15,7 +15,9 @@
 
 namespace Cheats {
 
-constexpr u64 run_interval_ticks = BASE_CLOCK_RATE_ARM11 / GPU::SCREEN_REFRESH_RATE;
+// Luma3DS uses this interval for applying cheats, so to keep consistent behavior
+// we use the same value
+constexpr u64 run_interval_ticks = 50'000'000;
 
 CheatEngine::CheatEngine(Core::System& system_) : system(system_) {
     LoadCheatFile();

--- a/src/core/cheats/gateway_cheat.cpp
+++ b/src/core/cheats/gateway_cheat.cpp
@@ -28,14 +28,18 @@ struct State {
     bool loop_flag = false;
 };
 
-template <typename T, typename WriteFunction>
+template <typename T, typename ReadFunction, typename WriteFunction>
 static inline std::enable_if_t<std::is_integral_v<T>> WriteOp(const GatewayCheat::CheatLine& line,
                                                               const State& state,
+                                                              ReadFunction read_func,
                                                               WriteFunction write_func,
                                                               Core::System& system) {
     u32 addr = line.address + state.offset;
-    write_func(addr, static_cast<T>(line.value));
-    system.CPU().InvalidateCacheRange(addr, sizeof(T));
+    T val = read_func(addr);
+    if (val != static_cast<T>(line.value)) {
+        write_func(addr, static_cast<T>(line.value));
+        system.CPU().InvalidateCacheRange(addr, sizeof(T));
+    }
 }
 
 template <typename T, typename ReadFunction, typename CompareFunc>
@@ -99,13 +103,16 @@ static inline void SetValueOp(const GatewayCheat::CheatLine& line, State& state)
     state.reg = line.value;
 }
 
-template <typename T, typename WriteFunction>
+template <typename T, typename ReadFunction, typename WriteFunction>
 static inline std::enable_if_t<std::is_integral_v<T>> IncrementiveWriteOp(
-    const GatewayCheat::CheatLine& line, State& state, WriteFunction write_func,
-    Core::System& system) {
+    const GatewayCheat::CheatLine& line, State& state, ReadFunction read_func,
+    WriteFunction write_func, Core::System& system) {
     u32 addr = line.value + state.offset;
-    write_func(addr, static_cast<T>(state.reg));
-    system.CPU().InvalidateCacheRange(addr, sizeof(T));
+    T val = read_func(addr);
+    if (val != static_cast<T>(state.reg)) {
+        write_func(addr, static_cast<T>(state.reg));
+        system.CPU().InvalidateCacheRange(addr, sizeof(T));
+    }
     state.offset += sizeof(T);
 }
 
@@ -272,15 +279,15 @@ void GatewayCheat::Execute(Core::System& system) const {
             break;
         case CheatType::Write32:
             // 0XXXXXXX YYYYYYYY - word[XXXXXXX+offset] = YYYYYYYY
-            WriteOp<u32>(line, state, Write32, system);
+            WriteOp<u32>(line, state, Read32, Write32, system);
             break;
         case CheatType::Write16:
             // 1XXXXXXX 0000YYYY - half[XXXXXXX+offset] = YYYY
-            WriteOp<u16>(line, state, Write16, system);
+            WriteOp<u16>(line, state, Read16, Write16, system);
             break;
         case CheatType::Write8:
             // 2XXXXXXX 000000YY - byte[XXXXXXX+offset] = YY
-            WriteOp<u8>(line, state, Write8, system);
+            WriteOp<u8>(line, state, Read8, Write8, system);
             break;
         case CheatType::GreaterThan32:
             // 3XXXXXXX YYYYYYYY - Execute next block IF YYYYYYYY > word[XXXXXXX]   ;unsigned
@@ -366,17 +373,17 @@ void GatewayCheat::Execute(Core::System& system) const {
         }
         case CheatType::IncrementiveWrite32: {
             // D6000000 XXXXXXXX – (32bit) [XXXXXXXX+offset] = reg ; offset += 4
-            IncrementiveWriteOp<u32>(line, state, Write32, system);
+            IncrementiveWriteOp<u32>(line, state, Read32, Write32, system);
             break;
         }
         case CheatType::IncrementiveWrite16: {
             // D7000000 XXXXXXXX – (16bit) [XXXXXXXX+offset] = reg & 0xffff ; offset += 2
-            IncrementiveWriteOp<u16>(line, state, Write16, system);
+            IncrementiveWriteOp<u16>(line, state, Read16, Write16, system);
             break;
         }
         case CheatType::IncrementiveWrite8: {
             // D8000000 XXXXXXXX – (16bit) [XXXXXXXX+offset] = reg & 0xff ; offset++
-            IncrementiveWriteOp<u8>(line, state, Write8, system);
+            IncrementiveWriteOp<u8>(line, state, Read8, Write8, system);
             break;
         }
         case CheatType::Load32: {

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -99,7 +99,7 @@ void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::GetInfraPriority(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x27, 0, 2);
-    const std::vector<u8>& ac_config = rp.PopStaticBuffer();
+    [[maybe_unused]] const std::vector<u8>& ac_config = rp.PopStaticBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1099,7 +1099,7 @@ void Module::Interface::BeginImportProgramTemporarily(Kernel::HLERequestContext&
 
 void Module::Interface::EndImportProgram(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0405, 0, 2); // 0x04050002
-    auto cia = rp.PopObject<Kernel::ClientSession>();
+    [[maybe_unused]] const auto cia = rp.PopObject<Kernel::ClientSession>();
 
     am->ScanForAllTitles();
 
@@ -1110,7 +1110,7 @@ void Module::Interface::EndImportProgram(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::EndImportProgramWithoutCommit(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0406, 0, 2); // 0x04060002
-    auto cia = rp.PopObject<Kernel::ClientSession>();
+    [[maybe_unused]] const auto cia = rp.PopObject<Kernel::ClientSession>();
 
     // Note: This function is basically a no-op for us since we don't use title.db
     // or ticket.db files to keep track of installed titles.
@@ -1123,10 +1123,10 @@ void Module::Interface::EndImportProgramWithoutCommit(Kernel::HLERequestContext&
 
 void Module::Interface::CommitImportPrograms(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0407, 3, 2); // 0x040700C2
-    auto media_type = static_cast<Service::FS::MediaType>(rp.Pop<u8>());
-    u32 title_count = rp.Pop<u32>();
-    u8 database = rp.Pop<u8>();
-    auto buffer = rp.PopMappedBuffer();
+    [[maybe_unused]] const auto media_type = static_cast<FS::MediaType>(rp.Pop<u8>());
+    [[maybe_unused]] const u32 title_count = rp.Pop<u32>();
+    [[maybe_unused]] const u8 database = rp.Pop<u8>();
+    const auto buffer = rp.PopMappedBuffer();
 
     // Note: This function is basically a no-op for us since we don't use title.db
     // or ticket.db files to keep track of installed titles.
@@ -1211,7 +1211,7 @@ ResultVal<std::unique_ptr<AMFileWrapper>> GetFileFromSession(
 
 void Module::Interface::GetProgramInfoFromCia(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0408, 1, 2); // 0x04080042
-    auto media_type = static_cast<Service::FS::MediaType>(rp.Pop<u8>());
+    [[maybe_unused]] const auto media_type = static_cast<FS::MediaType>(rp.Pop<u8>());
     auto cia = rp.PopObject<Kernel::ClientSession>();
 
     auto file_res = GetFileFromSession(cia);
@@ -1368,7 +1368,7 @@ void Module::Interface::GetCoreVersionFromCia(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::GetRequiredSizeFromCia(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x040D, 1, 2); // 0x040D0042
-    auto media_type = static_cast<Service::FS::MediaType>(rp.Pop<u8>());
+    [[maybe_unused]] const auto media_type = static_cast<FS::MediaType>(rp.Pop<u8>());
     auto cia = rp.PopObject<Kernel::ClientSession>();
 
     auto file_res = GetFileFromSession(cia);

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -425,11 +425,11 @@ void Module::APTInterface::PrepareToDoApplicationJump(Kernel::HLERequestContext&
 
 void Module::APTInterface::DoApplicationJump(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x32, 2, 4); // 0x00320084
-    u32 param_size = rp.Pop<u32>();
-    u32 hmac_size = rp.Pop<u32>();
+    const u32 param_size = rp.Pop<u32>();
+    const u32 hmac_size = rp.Pop<u32>();
 
-    auto param = rp.PopStaticBuffer();
-    auto hmac = rp.PopStaticBuffer();
+    [[maybe_unused]] const std::vector<u8>& param = rp.PopStaticBuffer();
+    [[maybe_unused]] const std::vector<u8>& hmac = rp.PopStaticBuffer();
 
     LOG_WARNING(Service_APT, "(STUBBED) called param_size={:08X}, hmac_size={:08X}", param_size,
                 hmac_size);
@@ -488,10 +488,10 @@ void Module::APTInterface::AppletUtility(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x4B, 3, 2); // 0x004B00C2
 
     // These are from 3dbrew - I'm not really sure what they're used for.
-    u32 utility_command = rp.Pop<u32>();
-    u32 input_size = rp.Pop<u32>();
-    u32 output_size = rp.Pop<u32>();
-    std::vector<u8> input = rp.PopStaticBuffer();
+    const auto utility_command = rp.Pop<u32>();
+    const auto input_size = rp.Pop<u32>();
+    const auto output_size = rp.Pop<u32>();
+    [[maybe_unused]] const std::vector<u8> input = rp.PopStaticBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS); // No error
@@ -579,21 +579,21 @@ void Module::APTInterface::StartLibraryApplet(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1E, 2, 4); // 0x1E0084
     AppletId applet_id = rp.PopEnum<AppletId>();
 
-    std::size_t buffer_size = rp.Pop<u32>();
+    [[maybe_unused]] const std::size_t buffer_size = rp.Pop<u32>();
     std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
-    std::vector<u8> buffer = rp.PopStaticBuffer();
+    const std::vector<u8> buffer = rp.PopStaticBuffer();
 
     LOG_DEBUG(Service_APT, "called, applet_id={:08X}", static_cast<u32>(applet_id));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(apt->applet_manager->StartLibraryApplet(applet_id, object, buffer));
+    rb.Push(apt->applet_manager->StartLibraryApplet(applet_id, std::move(object), buffer));
 }
 
 void Module::APTInterface::CloseApplication(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x27, 1, 4);
-    u32 parameters_size = rp.Pop<u32>();
-    std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
-    std::vector<u8> buffer = rp.PopStaticBuffer();
+    [[maybe_unused]] const u32 parameters_size = rp.Pop<u32>();
+    [[maybe_unused]] const std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
+    [[maybe_unused]] const std::vector<u8> buffer = rp.PopStaticBuffer();
 
     LOG_DEBUG(Service_APT, "called");
 

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -58,7 +58,7 @@ void Module::Interface::GetStorageInfo(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::RegisterPrivateRootCa(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x05, 1, 2);
-    const u32 size = rp.Pop<u32>();
+    [[maybe_unused]] const u32 size = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
@@ -96,7 +96,7 @@ void Module::Interface::GetNewArrivalFlag(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::RegisterNewArrivalEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x08, 0, 2);
-    const auto event = rp.PopObject<Kernel::Event>();
+    [[maybe_unused]] const auto event = rp.PopObject<Kernel::Event>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
@@ -282,7 +282,7 @@ void Module::Interface::SendProperty(Kernel::HLERequestContext& ctx) {
 void Module::Interface::SendPropertyHandle(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x15, 1, 2);
     const u16 property_id = rp.Pop<u16>();
-    const std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
+    [[maybe_unused]] const std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -353,8 +353,8 @@ void Module::Interface::Write(Kernel::HLERequestContext& ctx) {
                                      buffer);
         }
 
-        const u32 bytes_written =
-            session_data->file->Write(0, buffer.size(), true, buffer.data()).Unwrap();
+        [[maybe_unused]] const u32 bytes_written = static_cast<u32>(
+            session_data->file->Write(0, buffer.size(), true, buffer.data()).Unwrap());
         session_data->file->Close();
 
         rb.Push(RESULT_SUCCESS);
@@ -415,7 +415,8 @@ void Module::Interface::WriteMessage(Kernel::HLERequestContext& ctx) {
                   msg_header.sender_id, msg_header.sender_id2, msg_header.send_count,
                   msg_header.forward_count, msg_header.user_data);
 
-        const u32 bytes_written = message->Write(0, buffer_size, true, buffer.data()).Unwrap();
+        [[maybe_unused]] const u32 bytes_written =
+            static_cast<u32>(message->Write(0, buffer_size, true, buffer.data()).Unwrap());
         message->Close();
 
         rb.Push(RESULT_SUCCESS);
@@ -502,6 +503,8 @@ void Module::Interface::WriteMessageWithHMAC(Kernel::HLERequestContext& ctx) {
         std::memcpy(buffer.data() + hmac_offset, hmac_digest.data(), hmac_size);
 
         const u32 bytes_written = message->Write(0, buffer_size, true, buffer.data()).Unwrap();
+        [[maybe_unused]] const u32 bytes_written =
+            static_cast<u32>(message->Write(0, buffer_size, true, buffer.data()).Unwrap());
         message->Close();
 
         rb.Push(RESULT_SUCCESS);
@@ -743,7 +746,8 @@ void Module::Interface::OpenAndWrite(Kernel::HLERequestContext& ctx) {
                 cecd->CheckAndUpdateFile(path_type, ncch_program_id, buffer);
             }
 
-            const u32 bytes_written = file->Write(0, buffer.size(), true, buffer.data()).Unwrap();
+            [[maybe_unused]] const u32 bytes_written =
+                static_cast<u32>(file->Write(0, buffer.size(), true, buffer.data()).Unwrap());
             file->Close();
 
             rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -502,7 +502,6 @@ void Module::Interface::WriteMessageWithHMAC(Kernel::HLERequestContext& ctx) {
         hmac.CalculateDigest(hmac_digest.data(), message_body.data(), msg_header.body_size);
         std::memcpy(buffer.data() + hmac_offset, hmac_digest.data(), hmac_size);
 
-        const u32 bytes_written = message->Write(0, buffer_size, true, buffer.data()).Unwrap();
         [[maybe_unused]] const u32 bytes_written =
             static_cast<u32>(message->Write(0, buffer_size, true, buffer.data()).Unwrap());
         message->Close();

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -27,7 +27,7 @@
 namespace Service::CFG {
 
 /// The maximum number of block entries that can exist in the config file
-static const u32 CONFIG_FILE_MAX_BLOCK_ENTRIES = 1479;
+constexpr u32 CONFIG_FILE_MAX_BLOCK_ENTRIES = 1479;
 
 namespace {
 
@@ -89,22 +89,22 @@ struct ConsoleCountryInfo {
 static_assert(sizeof(ConsoleCountryInfo) == 4, "ConsoleCountryInfo must be exactly 4 bytes");
 } // namespace
 
-static const EULAVersion MAX_EULA_VERSION = {0x7F, 0x7F};
-static const ConsoleModelInfo CONSOLE_MODEL = {NINTENDO_3DS, {0, 0, 0}};
-static const u8 CONSOLE_LANGUAGE = LANGUAGE_EN;
-static const UsernameBlock CONSOLE_USERNAME_BLOCK = {u"vvctre", 0, 0};
-static const BirthdayBlock PROFILE_BIRTHDAY = {1, 4};
-static const u8 SOUND_OUTPUT_MODE = SOUND_STEREO;
+constexpr EULAVersion MAX_EULA_VERSION = {0x7F, 0x7F};
+constexpr ConsoleModelInfo CONSOLE_MODEL = {NINTENDO_3DS, {0, 0, 0}};
+constexpr u8 CONSOLE_LANGUAGE = LANGUAGE_EN;
+constexpr UsernameBlock CONSOLE_USERNAME_BLOCK = {u"vvctre", 0, 0};
+constexpr BirthdayBlock PROFILE_BIRTHDAY = {1, 4};
+constexpr u8 SOUND_OUTPUT_MODE = SOUND_STEREO;
 
 /// TODO(Subv): Find what the other bytes are
-static const ConsoleCountryInfo COUNTRY_INFO = {{0, 0, 0}, 36};
+constexpr ConsoleCountryInfo COUNTRY_INFO = {{0, 0, 0}, 36};
 
 /**
  * TODO(Subv): Find out what this actually is, these values fix some NaN uniforms in some games,
  * for example Nintendo Zone
  * Thanks Normmatt for providing this information
  */
-static const std::array<float, 8> STEREO_CAMERA_SETTINGS = {
+constexpr std::array<float, 8> STEREO_CAMERA_SETTINGS = {
     62.0f, 289.0f, 76.80000305175781f, 46.08000183105469f,
     10.0f, 5.0f,   55.58000183105469f, 21.56999969482422f,
 };

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <array>
 #include <tuple>
 #include <cryptopp/osrng.h>
 #include <cryptopp/sha.h>
@@ -110,7 +111,7 @@ static const std::array<float, 8> STEREO_CAMERA_SETTINGS = {
 static_assert(sizeof(STEREO_CAMERA_SETTINGS) == 0x20,
               "STEREO_CAMERA_SETTINGS must be exactly 0x20 bytes");
 
-static const std::vector<u8> cfg_system_savedata_id = {
+constexpr std::array<u8, 8> cfg_system_savedata_id{
     0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x01, 0x00,
 };
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -90,7 +90,7 @@ ArchiveManager::OpenFileFromArchive(ArchiveHandle archive_handle, const FileSys:
     if (backend.Failed())
         return std::make_tuple(backend.Code(), open_timeout_ns);
 
-    auto file = std::shared_ptr<File>(new File(system, std::move(backend).Unwrap(), path));
+    auto file = std::make_shared<File>(system, std::move(backend).Unwrap(), path);
     return std::make_tuple(MakeResult<std::shared_ptr<File>>(std::move(file)), open_timeout_ns);
 }
 
@@ -183,7 +183,7 @@ ResultVal<std::shared_ptr<Directory>> ArchiveManager::OpenDirectoryFromArchive(
     if (backend.Failed())
         return backend.Code();
 
-    auto directory = std::shared_ptr<Directory>(new Directory(std::move(backend).Unwrap(), path));
+    auto directory = std::make_shared<Directory>(std::move(backend).Unwrap(), path);
     return MakeResult<std::shared_ptr<Directory>>(std::move(directory));
 }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -225,15 +225,15 @@ void FS_USER::CreateFile(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x808, 8, 2);
 
     rp.Skip(1, false); // TransactionId
-    ArchiveHandle archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto filename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 filename_size = rp.Pop<u32>();
-    u32 attributes = rp.Pop<u32>();
-    u64 file_size = rp.Pop<u64>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto filename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto filename_size = rp.Pop<u32>();
+    const auto attributes = rp.Pop<u32>();
+    const auto file_size = rp.Pop<u64>();
     std::vector<u8> filename = rp.PopStaticBuffer();
     ASSERT(filename.size() == filename_size);
 
-    FileSys::Path file_path(filename_type, filename);
+    const FileSys::Path file_path(filename_type, std::move(filename));
 
     LOG_DEBUG(Service_FS, "type={} attributes={} size={:x} data={}",
               static_cast<u32>(filename_type), attributes, file_size, file_path.DebugStr());
@@ -245,13 +245,13 @@ void FS_USER::CreateFile(Kernel::HLERequestContext& ctx) {
 void FS_USER::CreateDirectory(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x809, 6, 2);
     rp.Skip(1, false); // TransactionId
-    ArchiveHandle archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 dirname_size = rp.Pop<u32>();
-    u32 attributes = rp.Pop<u32>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto dirname_size = rp.Pop<u32>();
+    [[maybe_unused]] const auto attributes = rp.Pop<u32>();
     std::vector<u8> dirname = rp.PopStaticBuffer();
     ASSERT(dirname.size() == dirname_size);
-    FileSys::Path dir_path(dirname_type, dirname);
+    const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
     LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr());
@@ -371,18 +371,18 @@ void FS_USER::FormatSaveData(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED)");
 
     IPC::RequestParser rp(ctx, 0x84C, 9, 2);
-    auto archive_id = rp.PopEnum<FS::ArchiveIdCode>();
-    auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 archivename_size = rp.Pop<u32>();
-    u32 block_size = rp.Pop<u32>();
-    u32 number_directories = rp.Pop<u32>();
-    u32 number_files = rp.Pop<u32>();
-    u32 directory_buckets = rp.Pop<u32>();
-    u32 file_buckets = rp.Pop<u32>();
-    bool duplicate_data = rp.Pop<bool>();
+    const auto archive_id = rp.PopEnum<ArchiveIdCode>();
+    const auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto archivename_size = rp.Pop<u32>();
+    const auto block_size = rp.Pop<u32>();
+    const auto number_directories = rp.Pop<u32>();
+    const auto number_files = rp.Pop<u32>();
+    [[maybe_unused]] const auto directory_buckets = rp.Pop<u32>();
+    [[maybe_unused]] const auto file_buckets = rp.Pop<u32>();
+    const bool duplicate_data = rp.Pop<bool>();
     std::vector<u8> archivename = rp.PopStaticBuffer();
     ASSERT(archivename.size() == archivename_size);
-    FileSys::Path archive_path(archivename_type, archivename);
+    const FileSys::Path archive_path(archivename_type, std::move(archivename));
 
     LOG_DEBUG(Service_FS, "archive_path={}", archive_path.DebugStr());
 
@@ -414,12 +414,12 @@ void FS_USER::FormatSaveData(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::FormatThisUserSaveData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x80F, 6, 0);
-    u32 block_size = rp.Pop<u32>();
-    u32 number_directories = rp.Pop<u32>();
-    u32 number_files = rp.Pop<u32>();
-    u32 directory_buckets = rp.Pop<u32>();
-    u32 file_buckets = rp.Pop<u32>();
-    bool duplicate_data = rp.Pop<bool>();
+    const auto block_size = rp.Pop<u32>();
+    const auto number_directories = rp.Pop<u32>();
+    const auto number_files = rp.Pop<u32>();
+    [[maybe_unused]] const auto directory_buckets = rp.Pop<u32>();
+    [[maybe_unused]] const auto file_buckets = rp.Pop<u32>();
+    const auto duplicate_data = rp.Pop<bool>();
 
     FileSys::ArchiveFormatInfo format_info;
     format_info.duplicate_data = duplicate_data;

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -410,7 +410,7 @@ void HTTP_C::CloseContext(Kernel::HLERequestContext& ctx) {
 void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x11, 3, 4);
     const u32 context_handle = rp.Pop<u32>();
-    const u32 name_size = rp.Pop<u32>();
+    [[maybe_unused]] const u32 name_size = rp.Pop<u32>();
     const u32 value_size = rp.Pop<u32>();
     const std::vector<u8> name_buffer = rp.PopStaticBuffer();
     Kernel::MappedBuffer& value_buffer = rp.PopMappedBuffer();
@@ -486,7 +486,7 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
 void HTTP_C::AddPostDataAscii(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x12, 3, 4);
     const u32 context_handle = rp.Pop<u32>();
-    const u32 name_size = rp.Pop<u32>();
+    [[maybe_unused]] const u32 name_size = rp.Pop<u32>();
     const u32 value_size = rp.Pop<u32>();
     const std::vector<u8> name_buffer = rp.PopStaticBuffer();
     Kernel::MappedBuffer& value_buffer = rp.PopMappedBuffer();

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1283,8 +1283,8 @@ void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx, u16 command_id,
 void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1E, 2, 4);
 
-    u8 connection_type = rp.Pop<u8>();
-    u32 passphrase_size = rp.Pop<u32>();
+    const auto connection_type = rp.Pop<u8>();
+    [[maybe_unused]] const auto passphrase_size = rp.Pop<u32>();
 
     const std::vector<u8> network_info_buffer = rp.PopStaticBuffer();
     ASSERT(network_info_buffer.size() == sizeof(NetworkInfo));
@@ -1304,8 +1304,8 @@ void NWM_UDS::ConnectToNetworkDeprecated(Kernel::HLERequestContext& ctx) {
     // info
     const auto network_info_buffer = rp.PopRaw<std::array<u8, 0x3C>>();
 
-    u8 connection_type = rp.Pop<u8>();
-    u32 passphrase_size = rp.Pop<u32>();
+    const auto connection_type = rp.Pop<u8>();
+    [[maybe_unused]] const auto passphrase_size = rp.Pop<u32>();
 
     std::vector<u8> passphrase = rp.PopStaticBuffer();
 

--- a/src/core/hle/service/ps/ps_ps.cpp
+++ b/src/core/hle/service/ps/ps_ps.cpp
@@ -39,8 +39,8 @@ constexpr std::array<u8, 10> KeyTypes{{
 
 void PS_PS::EncryptDecryptAes(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x4, 8, 4);
-    u32 src_size = rp.Pop<u32>();
-    u32 dest_size = rp.Pop<u32>();
+    auto src_size = rp.Pop<u32>();
+    [[maybe_unused]] const auto dest_size = rp.Pop<u32>();
 
     using CryptoPP::AES;
     std::array<u8, AES::BLOCKSIZE> iv;

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -27,17 +27,17 @@ constexpr int MAX_PENDING_NOTIFICATIONS = 16;
 void SRV::RegisterClient(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1, 0, 2);
 
-    u32 pid_descriptor = rp.Pop<u32>();
+    const auto pid_descriptor = rp.Pop<u32>();
     if (pid_descriptor != IPC::CallingPidDesc()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(IPC::ERR_INVALID_BUFFER_DESCRIPTOR);
         return;
     }
-    u32 caller_pid = rp.Pop<u32>();
+    const auto caller_pid = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
-    LOG_WARNING(Service_SRV, "(STUBBED) called");
+    LOG_WARNING(Service_SRV, "(STUBBED) called. Caller PID={}", caller_pid);
 }
 
 void SRV::EnableNotification(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <type_traits>
 #include <vector>
 #include "common/assert.h"
 #include "common/bit_field.h"
@@ -186,11 +187,6 @@ struct CTRPollFD {
         BitField<4, 1, u32> pollout;
         BitField<5, 1, u32> pollnval;
 
-        Events& operator=(const Events& other) {
-            hex = other.hex;
-            return *this;
-        }
-
         /// Translates the resulting events of a Poll operation from platform-specific to 3DS
         /// specific
         static Events TranslateTo3DS(u32 input_event) {
@@ -250,6 +246,8 @@ struct CTRPollFD {
         return result;
     }
 };
+static_assert(std::is_trivially_copyable_v<CTRPollFD>,
+              "CTRPollFD is used with std::memcpy and must be trivially copyable");
 
 /// Union to represent the 3DS' sockaddr structure
 union CTRSockAddr {

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -491,8 +491,8 @@ void SOC_U::Accept(Kernel::HLERequestContext& ctx) {
     // preventing graceful shutdown when closing the emulator, this can be fixed by always
     // performing nonblocking operations and spinlock until the data is available
     IPC::RequestParser rp(ctx, 0x04, 2, 2);
-    u32 socket_handle = rp.Pop<u32>();
-    socklen_t max_addr_len = static_cast<socklen_t>(rp.Pop<u32>());
+    const auto socket_handle = rp.Pop<u32>();
+    [[maybe_unused]] const auto max_addr_len = static_cast<socklen_t>(rp.Pop<u32>());
     rp.PopPID();
     sockaddr addr;
     socklen_t addr_len = sizeof(addr);
@@ -711,8 +711,8 @@ void SOC_U::Poll(Kernel::HLERequestContext& ctx) {
 
 void SOC_U::GetSockName(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x17, 2, 2);
-    u32 socket_handle = rp.Pop<u32>();
-    u32 max_addr_len = rp.Pop<u32>();
+    const auto socket_handle = rp.Pop<u32>();
+    [[maybe_unused]] const auto max_addr_len = rp.Pop<u32>();
     rp.PopPID();
 
     sockaddr dest_addr;
@@ -748,25 +748,26 @@ void SOC_U::Shutdown(Kernel::HLERequestContext& ctx) {
 
 void SOC_U::GetPeerName(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x18, 2, 2);
-    u32 socket_handle = rp.Pop<u32>();
-    u32 max_addr_len = rp.Pop<u32>();
+    const auto socket_handle = rp.Pop<u32>();
+    [[maybe_unused]] const auto max_addr_len = rp.Pop<u32>();
     rp.PopPID();
 
     sockaddr dest_addr;
     socklen_t dest_addr_len = sizeof(dest_addr);
-    int ret = ::getpeername(socket_handle, &dest_addr, &dest_addr_len);
+    const int ret = ::getpeername(socket_handle, &dest_addr, &dest_addr_len);
 
     CTRSockAddr ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
     std::vector<u8> dest_addr_buff(sizeof(ctr_dest_addr));
     std::memcpy(dest_addr_buff.data(), &ctr_dest_addr, sizeof(ctr_dest_addr));
 
     int result = 0;
-    if (ret != 0)
-        ret = TranslateError(GET_ERRNO);
+    if (ret != 0) {
+        result = TranslateError(GET_ERRNO);
+    }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push(ret);
+    rb.Push(result);
     rb.PushStaticBuffer(std::move(dest_addr_buff), 0);
 }
 
@@ -775,8 +776,8 @@ void SOC_U::Connect(Kernel::HLERequestContext& ctx) {
     // preventing graceful shutdown when closing the emulator, this can be fixed by always
     // performing nonblocking operations and spinlock until the data is available
     IPC::RequestParser rp(ctx, 0x06, 2, 4);
-    u32 socket_handle = rp.Pop<u32>();
-    u32 input_addr_len = rp.Pop<u32>();
+    const auto socket_handle = rp.Pop<u32>();
+    [[maybe_unused]] const auto input_addr_len = rp.Pop<u32>();
     rp.PopPID();
     auto input_addr_buf = rp.PopStaticBuffer();
 
@@ -796,7 +797,7 @@ void SOC_U::Connect(Kernel::HLERequestContext& ctx) {
 void SOC_U::InitializeSockets(Kernel::HLERequestContext& ctx) {
     // TODO(Subv): Implement
     IPC::RequestParser rp(ctx, 0x01, 1, 4);
-    u32 memory_block_size = rp.Pop<u32>();
+    [[maybe_unused]] const auto memory_block_size = rp.Pop<u32>();
     rp.PopPID();
     rp.PopObject<Kernel::SharedMemory>();
 
@@ -848,12 +849,12 @@ void SOC_U::GetSockOpt(Kernel::HLERequestContext& ctx) {
 
 void SOC_U::SetSockOpt(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x12, 4, 4);
-    u32 socket_handle = rp.Pop<u32>();
-    u32 level = rp.Pop<u32>();
-    s32 optname = rp.Pop<s32>();
-    socklen_t optlen = static_cast<socklen_t>(rp.Pop<u32>());
+    const auto socket_handle = rp.Pop<u32>();
+    const auto level = rp.Pop<u32>();
+    const auto optname = rp.Pop<s32>();
+    [[maybe_unused]] const auto optlen = static_cast<socklen_t>(rp.Pop<u32>());
     rp.PopPID();
-    auto optval = rp.PopStaticBuffer();
+    const auto optval = rp.PopStaticBuffer();
 
     s32 err = 0;
 

--- a/src/vvctre/common.h
+++ b/src/vvctre/common.h
@@ -4,6 +4,6 @@
 
 #include "common/common_types.h"
 
-const u8 vvctre_version_major = 28;
+const u8 vvctre_version_major = 29;
 const u8 vvctre_version_minor = 0;
-const u8 vvctre_version_patch = 1;
+const u8 vvctre_version_patch = 0;

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -332,14 +332,6 @@ void vvctre_write_u64(void* core, VAddr address, u64 value) {
     static_cast<Core::System*>(core)->Memory().Write64(address, value);
 }
 
-void* vvctre_malloc(std::size_t size) {
-    return std::malloc(size);
-}
-
-void vvctre_free(void* block) {
-    std::free(block);
-}
-
 // Debugging
 void vvctre_set_pc(void* core, u32 addr) {
     static_cast<Core::System*>(core)->CPU().SetPC(addr);
@@ -637,6 +629,13 @@ void vvctre_use_real_pad_state(void* core) {
     hid->SetCustomPadState(std::nullopt);
 }
 
+u32 vvctre_get_pad_state(void* core) {
+    std::shared_ptr<Service::HID::Module> hid =
+        Service::HID::GetModule(*static_cast<Core::System*>(core));
+
+    return hid->GetPadState().hex;
+}
+
 void vvctre_set_custom_circle_pad_state(void* core, float x, float y) {
     std::shared_ptr<Service::HID::Module> hid =
         Service::HID::GetModule(*static_cast<Core::System*>(core));
@@ -649,6 +648,15 @@ void vvctre_use_real_circle_pad_state(void* core) {
         Service::HID::GetModule(*static_cast<Core::System*>(core));
 
     hid->SetCustomCirclePadState(std::nullopt);
+}
+
+void vvctre_get_circle_pad_state(void* core, float* x_out, float* y_out) {
+    std::shared_ptr<Service::HID::Module> hid =
+        Service::HID::GetModule(*static_cast<Core::System*>(core));
+
+    const auto [x, y] = hid->GetCirclePadState();
+    *x_out = x;
+    *y_out = y;
 }
 
 void vvctre_set_custom_touch_state(void* core, float x, float y, bool pressed) {
@@ -665,6 +673,17 @@ void vvctre_use_real_touch_state(void* core) {
     hid->SetCustomTouchState(std::nullopt);
 }
 
+bool vvctre_get_touch_state(void* core, float* x_out, float* y_out) {
+    std::shared_ptr<Service::HID::Module> hid =
+        Service::HID::GetModule(*static_cast<Core::System*>(core));
+
+    const auto [x, y, pressed] = hid->GetTouchState();
+    *x_out = x;
+    *y_out = y;
+
+    return pressed;
+}
+
 void vvctre_set_custom_motion_state(void* core, float accelerometer[3], float gyroscope[3]) {
     std::shared_ptr<Service::HID::Module> hid =
         Service::HID::GetModule(*static_cast<Core::System*>(core));
@@ -679,6 +698,19 @@ void vvctre_use_real_motion_state(void* core) {
         Service::HID::GetModule(*static_cast<Core::System*>(core));
 
     hid->SetCustomPadState(std::nullopt);
+}
+
+void vvctre_get_motion_state(void* core, float accelerometer_out[3], float gyroscope_out[3]) {
+    std::shared_ptr<Service::HID::Module> hid =
+        Service::HID::GetModule(*static_cast<Core::System*>(core));
+
+    const auto [accelerometer, gyroscope] = hid->GetMotionState();
+    accelerometer_out[0] = accelerometer.x;
+    accelerometer_out[1] = accelerometer.y;
+    accelerometer_out[2] = accelerometer.z;
+    gyroscope_out[0] = gyroscope.x;
+    gyroscope_out[1] = gyroscope.y;
+    gyroscope_out[2] = gyroscope.z;
 }
 
 bool vvctre_screenshot(void* plugin_manager, void* data) {
@@ -1370,8 +1402,6 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     {"vvctre_write_u32", (void*)&vvctre_write_u32},
     {"vvctre_read_u64", (void*)&vvctre_read_u64},
     {"vvctre_write_u64", (void*)&vvctre_write_u64},
-    {"vvctre_malloc", (void*)&vvctre_malloc},
-    {"vvctre_free", (void*)&vvctre_free},
     // Debugging
     {"vvctre_set_pc", (void*)&vvctre_set_pc},
     {"vvctre_get_pc", (void*)&vvctre_get_pc},
@@ -1445,12 +1475,16 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     // Remote control
     {"vvctre_set_custom_pad_state", (void*)&vvctre_set_custom_pad_state},
     {"vvctre_use_real_pad_state", (void*)&vvctre_use_real_pad_state},
+    {"vvctre_get_pad_state", (void*)&vvctre_get_pad_state},
     {"vvctre_set_custom_circle_pad_state", (void*)&vvctre_set_custom_circle_pad_state},
     {"vvctre_use_real_circle_pad_state", (void*)&vvctre_use_real_circle_pad_state},
+    {"vvctre_get_circle_pad_state", (void*)&vvctre_get_circle_pad_state},
     {"vvctre_set_custom_touch_state", (void*)&vvctre_set_custom_touch_state},
     {"vvctre_use_real_touch_state", (void*)&vvctre_use_real_touch_state},
+    {"vvctre_get_touch_state", (void*)&vvctre_get_touch_state},
     {"vvctre_set_custom_motion_state", (void*)&vvctre_set_custom_motion_state},
     {"vvctre_use_real_motion_state", (void*)&vvctre_use_real_motion_state},
+    {"vvctre_get_motion_state", (void*)&vvctre_get_motion_state},
     {"vvctre_screenshot", (void*)&vvctre_screenshot},
     {"vvctre_screenshot_default_layout", (void*)&vvctre_screenshot_default_layout},
     // Settings


### PR DESCRIPTION
### Changes

- Port https://github.com/citra-emu/citra/pull/5315
- Port https://github.com/citra-emu/citra/pull/5324
- Port https://github.com/citra-emu/citra/pull/5305
- Port https://github.com/citra-emu/citra/pull/5318
- Port https://github.com/citra-emu/citra/pull/5319
- Port https://github.com/citra-emu/citra/pull/5320
- Correct output paths for executable binaries
- Add functions for plugins
  - vvctre_get_pad_state
  - vvctre_get_circle_pad_state
  - vvctre_get_touch_state
  - vvctre_get_motion_state
- Remove functions for plugins
  - vvctre_malloc
  - vvctre_free