### PR TITLE
29.4.0

### DIFF
--- a/src/vvctre/common.h
+++ b/src/vvctre/common.h
@@ -5,5 +5,5 @@
 #include "common/common_types.h"
 
 const u8 vvctre_version_major = 29;
-const u8 vvctre_version_minor = 3;
+const u8 vvctre_version_minor = 4;
 const u8 vvctre_version_patch = 0;

--- a/src/vvctre/emu_window/emu_window_sdl2.cpp
+++ b/src/vvctre/emu_window/emu_window_sdl2.cpp
@@ -198,6 +198,13 @@ EmuWindow_SDL2::EmuWindow_SDL2(Core::System& system, PluginManager& plugin_manag
     ImGui_ImplSDL2_InitForOpenGL(render_window, gl_context);
     ImGui_ImplOpenGL3_Init("#version 330 core");
 
+    ImGui::GetStyle().WindowRounding = 0.0f;
+    ImGui::GetStyle().ChildRounding = 0.0f;
+    ImGui::GetStyle().FrameRounding = 0.0f;
+    ImGui::GetStyle().GrabRounding = 0.0f;
+    ImGui::GetStyle().PopupRounding = 0.0f;
+    ImGui::GetStyle().ScrollbarRounding = 0.0f;
+
     DoneCurrent();
 }
 

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -527,16 +527,24 @@ bool vvctre_gui_begin_listbox(const char* label) {
     return ImGui::ListBoxHeader(label);
 }
 
+void vvctre_gui_end_listbox() {
+    ImGui::ListBoxFooter();
+}
+
+bool vvctre_gui_begin_combo_box(const char* label, const char* preview) {
+    return ImGui::BeginCombo(label, preview);
+}
+
+void vvctre_gui_end_combo_box() {
+    ImGui::EndCombo();
+}
+
 bool vvctre_gui_selectable(const char* label) {
     return ImGui::Selectable(label);
 }
 
 bool vvctre_gui_selectable_with_selected(const char* label, bool* selected) {
     return ImGui::Selectable(label, selected);
-}
-
-void vvctre_gui_end_listbox() {
-    ImGui::ListBoxFooter();
 }
 
 bool vvctre_gui_text_input(const char* label, char* buffer, size_t buffer_size) {
@@ -574,6 +582,11 @@ bool vvctre_gui_color_picker(const char* label, float* color, int flags) {
 
 void vvctre_gui_progress_bar(float value, const char* overlay) {
     ImGui::ProgressBar(value, ImVec2(-1, 0), overlay);
+}
+
+bool vvctre_gui_slider_u16(const char* label, u16* value, const u16 minimum, const u16 maximum,
+                           const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_U16, value, &minimum, &maximum, format);
 }
 
 void vvctre_gui_tooltip(const char* text) {
@@ -1456,6 +1469,7 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     {"vvctre_gui_bullet", (void*)&vvctre_gui_bullet},
     {"vvctre_gui_indent", (void*)&vvctre_gui_indent},
     {"vvctre_gui_unindent", (void*)&vvctre_gui_unindent},
+    {"vvctre_gui_tooltip", (void*)&vvctre_gui_tooltip},
     {"vvctre_gui_text", (void*)&vvctre_gui_text},
     {"vvctre_gui_text_colored", (void*)&vvctre_gui_text_colored},
     {"vvctre_gui_button", (void*)&vvctre_gui_button},
@@ -1471,9 +1485,11 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     {"vvctre_gui_menu_item", (void*)&vvctre_gui_menu_item},
     {"vvctre_gui_menu_item_with_check_mark", (void*)&vvctre_gui_menu_item_with_check_mark},
     {"vvctre_gui_begin_listbox", (void*)&vvctre_gui_begin_listbox},
+    {"vvctre_gui_end_listbox", (void*)&vvctre_gui_end_listbox},
+    {"vvctre_gui_begin_combo_box", (void*)&vvctre_gui_begin_combo_box},
+    {"vvctre_gui_end_combo_box", (void*)&vvctre_gui_end_combo_box},
     {"vvctre_gui_selectable", (void*)&vvctre_gui_selectable},
     {"vvctre_gui_selectable_with_selected", (void*)&vvctre_gui_selectable_with_selected},
-    {"vvctre_gui_end_listbox", (void*)&vvctre_gui_end_listbox},
     {"vvctre_gui_text_input", (void*)&vvctre_gui_text_input},
     {"vvctre_gui_text_input_multiline", (void*)&vvctre_gui_text_input},
     {"vvctre_gui_text_input_with_hint", (void*)&vvctre_gui_text_input},
@@ -1483,7 +1499,7 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     {"vvctre_gui_color_edit", (void*)&vvctre_gui_color_edit},
     {"vvctre_gui_color_picker", (void*)&vvctre_gui_color_picker},
     {"vvctre_gui_progress_bar", (void*)&vvctre_gui_progress_bar},
-    {"vvctre_gui_tooltip", (void*)&vvctre_gui_tooltip},
+    {"vvctre_gui_slider_u16", (void*)&vvctre_gui_slider_u16},
     // Button devices
     {"vvctre_button_device_new", (void*)&vvctre_button_device_new},
     {"vvctre_button_device_delete", (void*)&vvctre_button_device_delete},

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -466,6 +466,12 @@ void vvctre_gui_unindent() {
     ImGui::Unindent();
 }
 
+void vvctre_gui_tooltip(const char* text) {
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("%s", text);
+    }
+}
+
 void vvctre_gui_text(const char* text) {
     ImGui::TextUnformatted(text);
 }
@@ -587,12 +593,6 @@ void vvctre_gui_progress_bar(float value, const char* overlay) {
 bool vvctre_gui_slider_u16(const char* label, u16* value, const u16 minimum, const u16 maximum,
                            const char* format) {
     return ImGui::SliderScalar(label, ImGuiDataType_U16, value, &minimum, &maximum, format);
-}
-
-void vvctre_gui_tooltip(const char* text) {
-    if (ImGui::IsItemHovered()) {
-        ImGui::SetTooltip("%s", text);
-    }
 }
 
 // Button devices

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -602,9 +602,54 @@ void vvctre_gui_progress_bar(float value, const char* overlay) {
     ImGui::ProgressBar(value, ImVec2(-1, 0), overlay);
 }
 
+bool vvctre_gui_slider_u8(const char* label, u8* value, const u8 minimum, const u8 maximum,
+                          const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_U8, value, &minimum, &maximum, format);
+}
+
 bool vvctre_gui_slider_u16(const char* label, u16* value, const u16 minimum, const u16 maximum,
                            const char* format) {
     return ImGui::SliderScalar(label, ImGuiDataType_U16, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_u32(const char* label, u32* value, const u32 minimum, const u32 maximum,
+                           const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_U32, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_u64(const char* label, u64* value, const u64 minimum, const u64 maximum,
+                           const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_U64, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_s8(const char* label, s8* value, const s8 minimum, const s8 maximum,
+                          const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_S8, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_s16(const char* label, s16* value, const s16 minimum, const s16 maximum,
+                           const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_S16, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_s32(const char* label, s32* value, const s32 minimum, const s32 maximum,
+                           const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_S32, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_s64(const char* label, s64* value, const s64 minimum, const s64 maximum,
+                           const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_U64, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_float(const char* label, float* value, const float minimum,
+                             const float maximum, const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_Float, value, &minimum, &maximum, format);
+}
+
+bool vvctre_gui_slider_double(const char* label, double* value, const double minimum,
+                              const double maximum, const char* format) {
+    return ImGui::SliderScalar(label, ImGuiDataType_Double, value, &minimum, &maximum, format);
 }
 
 // Button devices
@@ -1514,7 +1559,16 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     {"vvctre_gui_color_edit", (void*)&vvctre_gui_color_edit},
     {"vvctre_gui_color_picker", (void*)&vvctre_gui_color_picker},
     {"vvctre_gui_progress_bar", (void*)&vvctre_gui_progress_bar},
+    {"vvctre_gui_slider_u8", (void*)&vvctre_gui_slider_u8},
     {"vvctre_gui_slider_u16", (void*)&vvctre_gui_slider_u16},
+    {"vvctre_gui_slider_u32", (void*)&vvctre_gui_slider_u32},
+    {"vvctre_gui_slider_u64", (void*)&vvctre_gui_slider_u64},
+    {"vvctre_gui_slider_s8", (void*)&vvctre_gui_slider_s8},
+    {"vvctre_gui_slider_s16", (void*)&vvctre_gui_slider_s16},
+    {"vvctre_gui_slider_s32", (void*)&vvctre_gui_slider_s32},
+    {"vvctre_gui_slider_s64", (void*)&vvctre_gui_slider_s64},
+    {"vvctre_gui_slider_float", (void*)&vvctre_gui_slider_float},
+    {"vvctre_gui_slider_double", (void*)&vvctre_gui_slider_double},
     // Button devices
     {"vvctre_button_device_new", (void*)&vvctre_button_device_new},
     {"vvctre_button_device_delete", (void*)&vvctre_button_device_delete},

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -446,6 +446,14 @@ void vvctre_reload_camera_images(void* core) {
 }
 
 // GUI
+void vvctre_gui_push_item_width(float item_width) {
+    ImGui::PushItemWidth(item_width);
+}
+
+void vvctre_gui_pop_item_width() {
+    ImGui::PopItemWidth();
+}
+
 void vvctre_gui_same_line() {
     ImGui::SameLine();
 }
@@ -1464,6 +1472,8 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     // Camera
     {"vvctre_reload_camera_images", (void*)&vvctre_reload_camera_images},
     // GUI
+    {"vvctre_gui_push_item_width", (void*)&vvctre_gui_push_item_width},
+    {"vvctre_gui_pop_item_width", (void*)&vvctre_gui_pop_item_width},
     {"vvctre_gui_same_line", (void*)&vvctre_gui_same_line},
     {"vvctre_gui_new_line", (void*)&vvctre_gui_new_line},
     {"vvctre_gui_bullet", (void*)&vvctre_gui_bullet},

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -509,6 +509,10 @@ bool vvctre_gui_begin(const char* name) {
     return ImGui::Begin(name);
 }
 
+bool vvctre_gui_begin_auto_resize(const char* name) {
+    return ImGui::Begin(name, nullptr, ImGuiWindowFlags_AlwaysAutoResize);
+}
+
 void vvctre_gui_end() {
     ImGui::End();
 }
@@ -1487,6 +1491,7 @@ std::unordered_map<std::string, void*> PluginManager::function_map = {
     {"vvctre_gui_color_button", (void*)&vvctre_gui_color_button},
     {"vvctre_gui_checkbox", (void*)&vvctre_gui_checkbox},
     {"vvctre_gui_begin", (void*)&vvctre_gui_begin},
+    {"vvctre_gui_begin_auto_resize", (void*)&vvctre_gui_begin_auto_resize},
     {"vvctre_gui_end", (void*)&vvctre_gui_end},
     {"vvctre_gui_begin_menu", (void*)&vvctre_gui_begin_menu},
     {"vvctre_gui_end_menu", (void*)&vvctre_gui_end_menu},

--- a/src/vvctre/plugins.cpp
+++ b/src/vvctre/plugins.cpp
@@ -539,16 +539,16 @@ void vvctre_gui_end_listbox() {
     ImGui::ListBoxFooter();
 }
 
-bool vvctre_gui_text_input(const char* label, char* buffer, std::size_t buffer_size) {
+bool vvctre_gui_text_input(const char* label, char* buffer, size_t buffer_size) {
     return ImGui::InputText(label, buffer, buffer_size);
 }
 
-bool vvctre_gui_text_input_multiline(const char* label, char* buffer, std::size_t buffer_size) {
+bool vvctre_gui_text_input_multiline(const char* label, char* buffer, size_t buffer_size) {
     return ImGui::InputTextMultiline(label, buffer, buffer_size);
 }
 
 bool vvctre_gui_text_input_with_hint(const char* label, const char* hint, char* buffer,
-                                     std::size_t buffer_size) {
+                                     size_t buffer_size) {
     return ImGui::InputTextWithHint(label, hint, buffer, buffer_size);
 }
 


### PR DESCRIPTION
### Changes

- Add functions for plugins
  - `vvctre_gui_begin_listbox`
  - `vvctre_gui_end_listbox`
  - `vvctre_gui_slider_u8`
  - `vvctre_gui_slider_u16`
  - `vvctre_gui_slider_u32`
  - `vvctre_gui_slider_u64`
  - `vvctre_gui_slider_s8`
  - `vvctre_gui_slider_s16`
  - `vvctre_gui_slider_s32`
  - `vvctre_gui_slider_s64`
  - `vvctre_gui_slider_float`
  - `vvctre_gui_slider_double`
  - `vvctre_gui_push_item_width`
  - `vvctre_gui_pop_item_width`
  - `vvctre_gui_begin_auto_resize`
- emu_window_sdl2: disable corner rounding
- Fix build error when trying to compile C plugin with generated `top.inc`
- Move some code